### PR TITLE
Force the BufferedReader to use utf-8

### DIFF
--- a/Laser.java
+++ b/Laser.java
@@ -48,7 +48,7 @@ public class Laser {
             System.err.println("FileError: Laser program files must end in .lsr");
             System.exit(1);
         }
-        BufferedReader in = new BufferedReader(new FileReader(args[0]));
+        BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(args[0]), "UTF-8"));
         ArrayList<String> lines = new ArrayList<String>();
         
         String line = null;


### PR DESCRIPTION
At current, on systems that do not use utf-8 by default, such as Windows, utf-8 characters like `⌞` will be interpreted by Laser as multiple individual characters.